### PR TITLE
Authorization Extension API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ If you want to be able to run the script from _any_ directory on your machine:
   API_CLIENT_ID=non-interactive-client-id
   API_CLIENT_SECRET=non-interactive-client-secret
   WEBTASK_TOKEN=your-tenant-webtask-token
+  AUTHZ_EXTENSION_ID=adf6e2f2b84784b57522e3b19dfc9201
   ```
 
   > `WEBTASK_TOKEN` is optional. Include it if you want the script to have access to your tenant's webtasks and extensions. To obtain the token, go to the desired tenant in the Auth0 Dashboard, then to Account Settings > [Webtasks](https://manage.auth0.com/#/account/webtasks) and copy it from the **Setup wt** step.

--- a/src/lib/runner.js
+++ b/src/lib/runner.js
@@ -1,9 +1,9 @@
-import { fetchAccessToken } from '../recipes/lib/auth0';
+import { tokenAudience, fetchAccessToken } from '../recipes/lib/auth0';
 
 export default (recipes, errorHandler) =>
   Promise.all([
     fetchAccessToken(process.env.AUTH0_DOMAIN, process.env.GLOBAL_CLIENT_ID, process.env.GLOBAL_CLIENT_SECRET),
-    fetchAccessToken(process.env.AUTH0_DOMAIN, process.env.API_CLIENT_ID, process.env.API_CLIENT_SECRET, `https://${process.env.AUTH0_DOMAIN}/api/v2/`)
+    fetchAccessToken(process.env.AUTH0_DOMAIN, process.env.API_CLIENT_ID, process.env.API_CLIENT_SECRET, tokenAudience())
   ])
     .then(tokens => {
       const accessTokens = {

--- a/src/recipes/lib/auth0.js
+++ b/src/recipes/lib/auth0.js
@@ -2,6 +2,14 @@ import * as request from './request';
 import querystring from 'querystring';
 import htmlTemplate from './templates';
 
+export function domain () {
+  return process.env.AUTH0_DOMAIN;
+}
+
+export function tokenAudience () {
+  return `https://${process.env.AUTH0_DOMAIN}/api/v2/`;
+}
+
 export function fetchAccessToken (auth0Domain, clientId, clientSecret, audience) {
   return request.post({
     url: `https://${auth0Domain}/oauth/token`,

--- a/src/recipes/lib/authz.js
+++ b/src/recipes/lib/authz.js
@@ -8,7 +8,7 @@ const REQUIRED_ACCESS_TOKEN_SCOPES = [
 ];
 
 export function apiBaseUrl () {
-  return `https://${process.env.AUTH0_TENANT}.${webtaskRegion()}.webtask.io/adf6e2f2b84784b57522e3b19dfc9201/api`;
+  return `https://${process.env.AUTH0_TENANT}.${webtaskRegion()}.webtask.io/${process.env.AUTHZ_EXTENSION_ID}/api`;
 }
 
 export function tokenAudience () {

--- a/src/recipes/lib/authz.js
+++ b/src/recipes/lib/authz.js
@@ -1,0 +1,105 @@
+import * as request from './request';
+import { webtaskRegion } from './webtask';
+
+const REQUIRED_ACCESS_TOKEN_SCOPES = [
+  'read:groups', 'create:groups', 'update:groups',
+  'read:roles', 'create:roles', 'update:roles',
+  'read:permissions', 'create:permissions'
+];
+
+export function apiBaseUrl () {
+  return `https://${process.env.AUTH0_TENANT}.${webtaskRegion()}.webtask.io/adf6e2f2b84784b57522e3b19dfc9201/api`;
+}
+
+export function tokenAudience () {
+  return 'urn:auth0-authz-api';
+}
+
+export function fetchAccessToken (apiV2AccessToken) {
+  const baseUrl = `https://${process.env.AUTH0_DOMAIN}/api/v2/client-grants`;
+
+  // check to see if script client has required client grants
+  return request.get({
+    url: baseUrl,
+    json: true,
+    auth: { bearer: apiV2AccessToken }
+  }, 'get existing client grants')
+    .then(grants => {
+      const grant = grants.find(g =>
+        g.client_id === process.env.API_CLIENT_ID &&
+        g.audience === tokenAudience());
+      if (!grant) {
+        // no grant record exists - create it
+        return request.post({
+          url: baseUrl,
+          json: {
+            client_id: process.env.API_CLIENT_ID,
+            audience: tokenAudience(),
+            scope: REQUIRED_ACCESS_TOKEN_SCOPES
+          },
+          auth: { bearer: apiV2AccessToken }
+        }, 'create client grant for Authorization API');
+      }
+
+      // find any missing scopes
+      const missingScopes = REQUIRED_ACCESS_TOKEN_SCOPES
+        .filter(scope => grant.scope.indexOf(scope) === -1);
+      // update grant with missing scopes
+      if (missingScopes.length > 0) {
+        return request.patch({
+          url: `${baseUrl}/${grant.id}`,
+          json: {
+            scope: grant.scope.concat(missingScopes)
+          },
+          auth: { bearer: apiV2AccessToken }
+        }, 'update client grant for Authorization API');
+      }
+    })
+    .then(() => request.post({
+      url: `https://${process.env.AUTH0_DOMAIN}/oauth/token`,
+      json: {
+        client_id: process.env.API_CLIENT_ID,
+        client_secret: process.env.API_CLIENT_SECRET,
+        grant_type: 'client_credentials',
+        audience: tokenAudience()
+      }
+    }, 'obtain access token'))
+    .then(body => body.access_token);
+}
+
+export function createEntity (entityName, idField, apiPath, accessToken, data) {
+  return request.post({
+    url: `${apiBaseUrl()}${apiPath}`,
+    auth: { bearer: accessToken },
+    json: data
+  },
+    `create ${entityName}`)
+      .then((entity) => {
+        console.log(`${entityName}: created ${entity[idField]}`);
+
+        return entity;
+      });
+}
+
+export function updateEntity (entityName, id, apiPath, subPath = '', accessToken, data, status) {
+  return request.patch({
+    url: `${apiBaseUrl()}${apiPath}/${id}${subPath}`,
+    auth: { bearer: accessToken },
+    json: data
+  },
+    `update ${entityName} ${id}`, status)
+      .then((entity) => {
+        console.log(`${entityName}: updated ${id}`);
+
+        return entity;
+      });
+}
+
+export function fetchEntity (entityName, id, apiPath, subPath = '', accessToken, data, status) {
+  return request.get({
+    url: `${apiBaseUrl()}${apiPath}/${id}${subPath}`,
+    auth: { bearer: accessToken },
+    json: true
+  },
+    `fetch ${entityName} ${id}`, status);
+}

--- a/src/recipes/lib/request.js
+++ b/src/recipes/lib/request.js
@@ -17,8 +17,8 @@ ${typeof(body) === 'object' ? util.inspect(body) : body}`));
   }));
 }
 
-export const get =   (opts, what) => wrapRequest('get', opts, 200, what);
-export const post =  (opts, what) => wrapRequest('post', opts, [ 200, 201 ], what);
-export const del =   (opts, what) => wrapRequest('del', opts, 204, what);
-export const patch = (opts, what) => wrapRequest('patch', opts, 200, what);
-export const put =   (opts, what) => wrapRequest('put', opts, 200, what);
+export const get =   (opts, what, status = 200) => wrapRequest('get', opts, status, what);
+export const post =  (opts, what, status = [ 200, 201 ]) => wrapRequest('post', opts, status, what);
+export const del =   (opts, what, status = 204) => wrapRequest('del', opts, status, what);
+export const patch = (opts, what, status = 200) => wrapRequest('patch', opts, status, what);
+export const put =   (opts, what, status = 200) => wrapRequest('put', opts, status, what);

--- a/src/recipes/lib/webtask.js
+++ b/src/recipes/lib/webtask.js
@@ -1,10 +1,15 @@
 import * as request from './request';
 import querystring from 'querystring';
 
-export function apiManager (entityName, idField, apiPath, accessToken, pager = getPage => getPage({})) {
+export function webtaskRegion () {
   const regionMatch = /^\S*\.(\S*)\.auth0\.com$/.exec(process.env.AUTH0_DOMAIN);
-  const region = regionMatch ? `-${regionMatch[1]}` : '';
-  const rootUrl = `https://sandbox${region}.it.auth0.com${apiPath}/${process.env.AUTH0_TENANT}`;
+  return regionMatch ? regionMatch[1] : 'us';
+}
+
+export function apiManager (entityName, idField, apiPath, accessToken, pager = getPage => getPage({})) {
+  const region = webtaskRegion();
+  const apiRegion = region === 'us' ? '' : `-${region}`;
+  const rootUrl = `https://sandbox${apiRegion}.it.auth0.com${apiPath}/${process.env.AUTH0_TENANT}`;
 
   return {
     entityName,


### PR DESCRIPTION
Adds a new module to `src/recipes/lib` that makes it easy to call the [Auth0 Authorization Extension API](https://auth0.com/docs/extensions/authorization-extension#enabling-api-access).

One big feature is the [fetchAccessToken](https://github.com/twistedstream/auth0-reset-tenant/blob/6762203bc550b9a111e111b1f259626fe4c9fb47/src/recipes/lib/authz.js#L18) method, which dynamically adds the needed client grant scopes to the non-interactive client used by the `reset-tenant` script so that groups, roles, permissions can be created in a recipe. 

> This approach may actually be a good idea for the [auth0](https://github.com/twistedstream/auth0-reset-tenant/blob/6762203bc550b9a111e111b1f259626fe4c9fb47/src/recipes/lib/auth0.js) library as well. It would make initial CLI setup easier since you'd only have to enable the `read:client_grants`, `update:client_grants`, and `create:client_grants`client grant scopes instead of the larger list shown in the [README](https://github.com/twistedstream/auth0-reset-tenant/blob/6762203bc550b9a111e111b1f259626fe4c9fb47/README.md)