### PR TITLE
Support new Management API token limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,17 @@ The `.auth0-reset-tenant-env` file is useful when you have a common Auth0 tenant
 Regardless, the configuration file requires the following name/value pairs:
 
 ```
-AUTH0_TENANT=yourtenant
-AUTH0_DOMAIN=yourtenant.auth0.com
-GLOBAL_CLIENT_ID=global-client-id
-GLOBAL_CLIENT_SECRET=global-client-secret
-API_CLIENT_ID=non-interactive-client-id
-API_CLIENT_SECRET=non-interactive-client-secret
-WEBTASK_TOKEN=your-tenant-webtask-token
-AUTHZ_EXTENSION_ID=adf6e2f2b84784b57522e3b19dfc9201
+RESETTENANT_AUTH0_TENANT=yourtenant
+RESETTENANT_AUTH0_DOMAIN=yourtenant.auth0.com
+RESETTENANT_NIC_CLIENT_ID=non-interactive-client-id
+RESETTENANT_NIC_CLIENT_SECRET=non-interactive-client-secret
+RESETTENANT_GLOBAL_CLIENT_ID=global-client-id
+RESETTENANT_GLOBAL_CLIENT_SECRET=global-client-secret
+RESETTENANT_WEBTASK_TOKEN=your-tenant-webtask-token
+RESETTENANT_AUTHZ_EXTENSION_ID=adf6e2f2b84784b57522e3b19dfc9201
 ```
 
-> `WEBTASK_TOKEN` is optional. Include it if you want the script to have access to your tenant's webtasks and extensions. To obtain the token, go to the desired tenant in the Auth0 Dashboard, then to Account Settings > [Webtasks](https://manage.auth0.com/#/account/webtasks) and copy it from the **Setup wt** step.
+> `RESETTENANT_WEBTASK_TOKEN` is optional. Include it if you want the script to have access to your tenant's webtasks and extensions. To obtain the token, go to the desired tenant in the Auth0 Dashboard, then to Account Settings > [Webtasks](https://manage.auth0.com/#/account/webtasks) and copy it from the **Setup wt** step.
 
 ### Global Setup
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-reset-tenant",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "An Auth0 CLI tool/extension that can be used to reset an Auth0 tenant to a known set of artifacts.",
   "scripts": {
     "clean": "rimraf dist",

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ const commandLineArgs = process.argv.slice(2);
 
 console.log(`${colors.cyan(pkg.name)}, version ${pkg.version}`);
 console.log(pkg.description);
-console.log(`Target Auth0 domain: ${colors.yellow(process.env.AUTH0_DOMAIN)}`);
+console.log(`Target Auth0 domain: ${colors.yellow(process.env.RESETTENANT_AUTH0_DOMAIN)}`);
 console.log(`[.env file: ${envFile}]`);
 console.log();
 

--- a/src/lib/env.js
+++ b/src/lib/env.js
@@ -3,7 +3,7 @@ import path from 'path';
 import os from 'os';
 
 const envFiles = [
-  path.join(__dirname, '../../.env'),
+  path.join(process.cwd(), '.env'),
   path.join(os.homedir(), '.auth0-reset-tenant-env')
 ];
 export const envFile = envFiles.find(file => fs.existsSync(file));

--- a/src/lib/runner.js
+++ b/src/lib/runner.js
@@ -1,9 +1,60 @@
 import { tokenAudience, fetchAccessToken } from '../recipes/lib/auth0';
+import * as request from '../recipes/lib/request';
+import colors from 'colors/safe';
+
+const MINIMUM_MANAGEMENT_API_CLIENT_GRANT_SCOPES = [
+  'read:client_grants', 
+  'update:client_grants' 
+];
+
+function getRequiredClientGrantScopes (recipes) {
+  return recipes.reduce((previous, current) => {
+    const newScopes = [];
+    current.managementApiClientGrantScopes.forEach(scope => {
+      if (!previous.includes(scope)) {
+        newScopes.push(scope);
+      }
+    });
+
+    return previous.concat(newScopes);
+  }, MINIMUM_MANAGEMENT_API_CLIENT_GRANT_SCOPES);
+}
+
+function updateClientGrantScopesForManagementApi (scopes, apiV2AccessToken) {
+  const baseUrl = `https://${process.env.RESETTENANT_AUTH0_DOMAIN}/api/v2/client-grants`;
+
+  return request.get({
+    url: baseUrl,
+    json: true,
+    auth: { bearer: apiV2AccessToken }
+  }, 'get existing client grants')
+    .then(grants => {
+      const grant = grants.find(g =>
+        g.client_id === process.env.RESETTENANT_NIC_CLIENT_ID &&
+        g.audience === tokenAudience());
+      if (!grant) {
+        throw new Error(`Non Interactive Client (Client ID=${process.env.RESETTENANT_NIC_CLIENT_ID}) does not have a grant record for the Auth0 Management API.`);
+      }
+
+      return request.patch({
+        url: `${baseUrl}/${grant.id}`,
+        json: { scope: scopes },
+        auth: { bearer: apiV2AccessToken }
+      }, 'update client grants for Management API');
+    });
+}
 
 export default (recipes, errorHandler) =>
   Promise.all([
-    fetchAccessToken(process.env.RESETTENANT_AUTH0_DOMAIN, process.env.RESETTENANT_GLOBAL_CLIENT_ID, process.env.RESETTENANT_GLOBAL_CLIENT_SECRET),
-    fetchAccessToken(process.env.RESETTENANT_AUTH0_DOMAIN, process.env.RESETTENANT_NIC_CLIENT_ID, process.env.RESETTENANT_NIC_CLIENT_SECRET, tokenAudience())
+    fetchAccessToken(
+      process.env.RESETTENANT_AUTH0_DOMAIN, 
+      process.env.RESETTENANT_GLOBAL_CLIENT_ID, 
+      process.env.RESETTENANT_GLOBAL_CLIENT_SECRET),
+    fetchAccessToken(
+      process.env.RESETTENANT_AUTH0_DOMAIN, 
+      process.env.RESETTENANT_NIC_CLIENT_ID, 
+      process.env.RESETTENANT_NIC_CLIENT_SECRET, 
+      tokenAudience())
   ])
     .then(tokens => {
       const accessTokens = {
@@ -11,17 +62,46 @@ export default (recipes, errorHandler) =>
         v2: tokens[1],
         webtask: process.env.RESETTENANT_WEBTASK_TOKEN
       };
-      console.log('Access tokens obtained.');
 
-      // run selected recipes
-      return recipes.reduce((previous, current) => {
-        return previous.then(() => {
-          console.log();
-          console.log(current.name);
-          console.log('-'.repeat(current.name.length));
+      console.log('Initial access tokens obtained.');
 
-          return current.run(accessTokens);
+      // temporarily update the NIC's client grants to include all grants specified by the recipes
+      const requiredScopes = getRequiredClientGrantScopes(recipes);
+
+      return updateClientGrantScopesForManagementApi(requiredScopes, accessTokens.v2)
+        .then(() => {
+          console.log('Reset Tenant\'s client grant modified with Management API scopes required by the selected recipes:');
+          console.log(colors.cyan(requiredScopes.join(', ')));
+        })
+        // obtain new v2 access token which has updated scopes
+        .then(() => fetchAccessToken(
+          process.env.RESETTENANT_AUTH0_DOMAIN, 
+          process.env.RESETTENANT_NIC_CLIENT_ID, 
+          process.env.RESETTENANT_NIC_CLIENT_SECRET, 
+          tokenAudience()))
+        .then(newApiV2AccessToken => {
+          accessTokens.v2 = newApiV2AccessToken;
+
+          console.log('Updated access tokens obtained.');
+
+          // run selected recipes
+          return recipes.reduce((previous, current) => {
+            return previous.then(() => {
+              console.log();
+              console.log(current.name);
+              console.log('-'.repeat(current.name.length));
+
+              return current.run(accessTokens);
+            });
+          }, Promise.resolve());
+        })
+        // reset NIC's client grants back to default
+        .then(() => updateClientGrantScopesForManagementApi(
+          MINIMUM_MANAGEMENT_API_CLIENT_GRANT_SCOPES, 
+          accessTokens.v2))
+        .then(() => {
+          console.log('Reset Tenant\'s client grant returned to minimum Management API scopes:');
+          console.log(colors.cyan(MINIMUM_MANAGEMENT_API_CLIENT_GRANT_SCOPES.join(', ')));
         });
-      }, Promise.resolve());
     })
     .catch(errorHandler);

--- a/src/lib/runner.js
+++ b/src/lib/runner.js
@@ -2,14 +2,14 @@ import { tokenAudience, fetchAccessToken } from '../recipes/lib/auth0';
 
 export default (recipes, errorHandler) =>
   Promise.all([
-    fetchAccessToken(process.env.AUTH0_DOMAIN, process.env.GLOBAL_CLIENT_ID, process.env.GLOBAL_CLIENT_SECRET),
-    fetchAccessToken(process.env.AUTH0_DOMAIN, process.env.API_CLIENT_ID, process.env.API_CLIENT_SECRET, tokenAudience())
+    fetchAccessToken(process.env.RESETTENANT_AUTH0_DOMAIN, process.env.RESETTENANT_GLOBAL_CLIENT_ID, process.env.RESETTENANT_GLOBAL_CLIENT_SECRET),
+    fetchAccessToken(process.env.RESETTENANT_AUTH0_DOMAIN, process.env.RESETTENANT_NIC_CLIENT_ID, process.env.RESETTENANT_NIC_CLIENT_SECRET, tokenAudience())
   ])
     .then(tokens => {
       const accessTokens = {
         v1: tokens[0],
         v2: tokens[1],
-        webtask: process.env.WEBTASK_TOKEN
+        webtask: process.env.RESETTENANT_WEBTASK_TOKEN
       };
       console.log('Access tokens obtained.');
 

--- a/src/recipes/builtin/api_authn_authz.js
+++ b/src/recipes/builtin/api_authn_authz.js
@@ -10,7 +10,7 @@ export const run = (accessTokens) =>
   Promise.all([
     // Enable OAuth2 as a Service flag
     request.patch({
-      url: `https://${process.env.AUTH0_DOMAIN}/api/v2/tenants/settings`,
+      url: `https://${process.env.RESETTENANT_AUTH0_DOMAIN}/api/v2/tenants/settings`,
       auth: { bearer: accessTokens.v2 },
       json: {
         flags: {
@@ -34,7 +34,7 @@ export const run = (accessTokens) =>
         createEntity('Connection', 'id', '/api/v2/connections', accessTokens.v2, {
           name: DB_CONNECTION_NAME,
           strategy: 'auth0',
-          enabled_clients: [ client.client_id, process.env.API_CLIENT_ID ]
+          enabled_clients: [ client.client_id, process.env.RESETTENANT_NIC_CLIENT_ID ]
         })
         // Add a single user
         .then(connection =>
@@ -48,7 +48,7 @@ export const run = (accessTokens) =>
               name: 'Foo Bar'
             }
           })
-          // remove API_CLIENT_ID from the connection's enabled clients
+          // remove RESETTENANT_NIC_CLIENT_ID from the connection's enabled clients
           .then(() =>
             updateEntity('Connection', connection.id, '/api/v2/connections', accessTokens.v2, {
               enabled_clients: [ client.client_id ]

--- a/src/recipes/builtin/api_authn_authz.js
+++ b/src/recipes/builtin/api_authn_authz.js
@@ -5,6 +5,13 @@ const DB_CONNECTION_NAME = 'Task-Users';
 
 export const name = 'API Authentication & Authorization';
 export const description = 'Creates a SPA that uses a database connection with a single user as well as an API';
+export const managementApiClientGrantScopes = [ 
+  'update:tenant_settings', 
+  'create:clients', 
+  'create:connections', 'update:connections', 
+  'create:users', 
+  'create:resource_servers' 
+];
 
 export const run = (accessTokens) =>
   Promise.all([

--- a/src/recipes/builtin/clear.js
+++ b/src/recipes/builtin/clear.js
@@ -25,7 +25,7 @@ export const run = (accessTokens) => Promise.all([
   // Delete all clients except this one and the global client
   auth0.deleteEntities(
     auth0.apiManager('Client', 'client_id', '/api/v2/clients', accessTokens.v2),
-    c => c.client_id !== process.env.API_CLIENT_ID && !c.global),
+    c => c.client_id !== process.env.RESETTENANT_NIC_CLIENT_ID && !c.global),
   // Delete all connections (should remove associated users)
   auth0.deleteEntities(
     auth0.apiManager('Connection', 'id', '/api/v2/connections', accessTokens.v2)),
@@ -42,17 +42,17 @@ export const run = (accessTokens) => Promise.all([
   // Delete client grants not accociated with this client
   auth0.deleteEntities(
     auth0.apiManager('Client Grant', 'id', '/api/v2/client-grants', accessTokens.v2),
-    g => g.client_id !== process.env.API_CLIENT_ID),
+    g => g.client_id !== process.env.RESETTENANT_NIC_CLIENT_ID),
   // Delete the email provider
   request.del({
-    url: `https://${process.env.AUTH0_DOMAIN}/api/v2/emails/provider`,
+    url: `https://${process.env.RESETTENANT_AUTH0_DOMAIN}/api/v2/emails/provider`,
     auth: { bearer: accessTokens.v2 },
     json: true
   }, 'delete email provider')
     .then(() => console.log('Custom Email Provider: deleted')),
   // Reset the tenant settings
   request.patch({
-    url: `https://${process.env.AUTH0_DOMAIN}/api/v2/tenants/settings`,
+    url: `https://${process.env.RESETTENANT_AUTH0_DOMAIN}/api/v2/tenants/settings`,
     auth: { bearer: accessTokens.v2 },
     json: {
       change_password: {
@@ -85,7 +85,7 @@ export const run = (accessTokens) => Promise.all([
     .then(() => console.log('Tenant Settings: reset')),
   // Reset login page
   request.patch({
-    url: `https://${process.env.AUTH0_DOMAIN}/api/v2/clients/${process.env.GLOBAL_CLIENT_ID}`,
+    url: `https://${process.env.RESETTENANT_AUTH0_DOMAIN}/api/v2/clients/${process.env.RESETTENANT_GLOBAL_CLIENT_ID}`,
     auth: { bearer: accessTokens.v2 },
     json: {
       custom_login_page: htmlTemplate('hosted', 'login'),

--- a/src/recipes/builtin/clear.js
+++ b/src/recipes/builtin/clear.js
@@ -5,6 +5,17 @@ import * as webtask from '../lib/webtask';
 
 export const name = 'Clear';
 export const description = 'Removes all entities from the tenant (including webtasks/extensions) and puts settings back to their defaults';
+export const managementApiClientGrantScopes = [ 
+  'update:tenant_settings', 
+  'read:client_grants', 'delete:client_grants',
+  'read:users', 'delete:users',
+  'read:clients', 'delete:clients', 'update:clients',
+  'read:connections', 'delete:connections',
+  'read:resource_servers', 'delete:resource_servers',
+  'read:device_credentials', 'delete:device_credentials',
+  'read:rules', 'delete:rules',
+  'delete:email_provider'
+];
 
 export const run = (accessTokens) => Promise.all([
   // Delete all users

--- a/src/recipes/builtin/demo_multitenant_website_sample.js
+++ b/src/recipes/builtin/demo_multitenant_website_sample.js
@@ -20,7 +20,7 @@ export const run = (accessTokens) =>
       createEntity('Connection', 'id', '/api/v2/connections', accessTokens.v2, {
         name: DB_CONNECTION_NAME,
         strategy: 'auth0',
-        enabled_clients: [ client.client_id, process.env.API_CLIENT_ID ]
+        enabled_clients: [ client.client_id, process.env.RESETTENANT_NIC_CLIENT_ID ]
       })
       .then(connection =>
         Promise.all([
@@ -84,7 +84,7 @@ export const run = (accessTokens) =>
 }`
           })          
         ])
-        // remove API_CLIENT_ID from the connection's enabled clients
+        // remove RESETTENANT_NIC_CLIENT_ID from the connection's enabled clients
         .then(() =>
           updateEntity('Connection', connection.id, '/api/v2/connections', accessTokens.v2, {
             enabled_clients: [ client.client_id ]

--- a/src/recipes/builtin/demo_multitenant_website_sample.js
+++ b/src/recipes/builtin/demo_multitenant_website_sample.js
@@ -4,6 +4,12 @@ const DB_CONNECTION_NAME = 'Username-Password-Authentication';
 
 export const name = 'Demo: Multi-tenant Website Sample';
 export const description = 'Performs the Auth0 setup for the sample: https://github.com/auth0-samples/auth0-multitenant-website';
+export const managementApiClientGrantScopes = [ 
+  'create:clients',
+  'create:connections', 'update:connections',
+  'create:users',
+  'create:rules'
+];
 
 export const run = (accessTokens) =>
   // Create a regular web application

--- a/src/recipes/builtin/new_tenant.js
+++ b/src/recipes/builtin/new_tenant.js
@@ -2,6 +2,10 @@ import { createEntity } from '../lib/auth0';
 
 export const name = 'New Tenant';
 export const description = 'Creates all the elements in a new Auth0 Tenant';
+export const managementApiClientGrantScopes = [ 
+  'create:clients',
+  'create:connections'
+];
 
 export const run = (accessTokens) =>
   // Create a regular web application

--- a/src/recipes/builtin/regular_web_app.js
+++ b/src/recipes/builtin/regular_web_app.js
@@ -4,6 +4,11 @@ const DB_CONNECTION_NAME = 'Sweet-App-Users';
 
 export const name = 'Regular Web App';
 export const description = 'Creates a regular web app that uses a database connection with a single user';
+export const managementApiClientGrantScopes = [ 
+  'create:clients',
+  'create:connections', 'update:connections',
+  'create:users'
+];
 
 export const run = (accessTokens) =>
   // Create a regular web application

--- a/src/recipes/builtin/regular_web_app.js
+++ b/src/recipes/builtin/regular_web_app.js
@@ -17,7 +17,7 @@ export const run = (accessTokens) =>
       createEntity('Connection', 'id', '/api/v2/connections', accessTokens.v2, {
         name: DB_CONNECTION_NAME,
         strategy: 'auth0',
-        enabled_clients: [ client.client_id, process.env.API_CLIENT_ID ]
+        enabled_clients: [ client.client_id, process.env.RESETTENANT_NIC_CLIENT_ID ]
       })
       // Add a single user
       .then(connection =>
@@ -31,7 +31,7 @@ export const run = (accessTokens) =>
             name: 'Foo Bar'
           }
         })
-        // remove API_CLIENT_ID from the connection's enabled clients
+        // remove RESETTENANT_NIC_CLIENT_ID from the connection's enabled clients
         .then(() =>
           updateEntity('Connection', connection.id, '/api/v2/connections', accessTokens.v2, {
             enabled_clients: [ client.client_id ]

--- a/src/recipes/lib/auth0.js
+++ b/src/recipes/lib/auth0.js
@@ -3,11 +3,11 @@ import querystring from 'querystring';
 import htmlTemplate from './templates';
 
 export function domain () {
-  return process.env.AUTH0_DOMAIN;
+  return process.env.RESETTENANT_AUTH0_DOMAIN;
 }
 
 export function tokenAudience () {
-  return `https://${process.env.AUTH0_DOMAIN}/api/v2/`;
+  return `https://${process.env.RESETTENANT_AUTH0_DOMAIN}/api/v2/`;
 }
 
 export function fetchAccessToken (auth0Domain, clientId, clientSecret, audience) {
@@ -48,14 +48,14 @@ export function apiManager (entityName, idField, apiPath, accessToken, pager = g
     idField,
     getAll: () => {
       const getPage = (params) => request.get({
-        url: `https://${process.env.AUTH0_DOMAIN}${apiPath}?${querystring.stringify(params)}`,
+        url: `https://${process.env.RESETTENANT_AUTH0_DOMAIN}${apiPath}?${querystring.stringify(params)}`,
         auth: { bearer: accessToken },
         json: true
       }, `fetch ${entityName}s`);
       return pager(getPage);
     },
     delete: id => request.del({
-      url: `https://${process.env.AUTH0_DOMAIN}${apiPath}/${id}`,
+      url: `https://${process.env.RESETTENANT_AUTH0_DOMAIN}${apiPath}/${id}`,
       auth: { bearer: accessToken },
       json: true
     }, `delete ${entityName}`)
@@ -63,7 +63,7 @@ export function apiManager (entityName, idField, apiPath, accessToken, pager = g
 }
 
 export function resetEmailTemplate (type, name, accessToken, settings) {
-  const url = `https://${process.env.AUTH0_DOMAIN}/api/emails/${type}`;
+  const url = `https://${process.env.RESETTENANT_AUTH0_DOMAIN}/api/emails/${type}`;
   const auth = { bearer: accessToken };
 
   // make sure email template exists
@@ -81,7 +81,7 @@ export function resetEmailTemplate (type, name, accessToken, settings) {
           url,
           auth,
           json: Object.assign({
-            tenant: process.env.AUTH0_TENANT,
+            tenant: process.env.RESETTENANT_AUTH0_TENANT,
             from: '',
             subject: '',
             body: htmlTemplate('email', type),
@@ -95,7 +95,7 @@ export function resetEmailTemplate (type, name, accessToken, settings) {
 
 export function createEntity (entityName, idField, apiPath, accessToken, data) {
   return request.post({
-    url: `https://${process.env.AUTH0_DOMAIN}${apiPath}`,
+    url: `https://${process.env.RESETTENANT_AUTH0_DOMAIN}${apiPath}`,
     auth: { bearer: accessToken },
     json: data
   },
@@ -109,7 +109,7 @@ export function createEntity (entityName, idField, apiPath, accessToken, data) {
 
 export function updateEntity (entityName, id, apiPath, accessToken, data) {
   return request.patch({
-    url: `https://${process.env.AUTH0_DOMAIN}${apiPath}/${id}`,
+    url: `https://${process.env.RESETTENANT_AUTH0_DOMAIN}${apiPath}/${id}`,
     auth: { bearer: accessToken },
     json: data
   },

--- a/src/recipes/lib/authz.js
+++ b/src/recipes/lib/authz.js
@@ -8,7 +8,7 @@ const REQUIRED_ACCESS_TOKEN_SCOPES = [
 ];
 
 export function apiBaseUrl () {
-  return `https://${process.env.AUTH0_TENANT}.${webtaskRegion()}.webtask.io/${process.env.AUTHZ_EXTENSION_ID}/api`;
+  return `https://${process.env.RESETTENANT_AUTH0_TENANT}.${webtaskRegion()}.webtask.io/${process.env.RESETTENANT_AUTHZ_EXTENSION_ID}/api`;
 }
 
 export function tokenAudience () {
@@ -16,7 +16,7 @@ export function tokenAudience () {
 }
 
 export function fetchAccessToken (apiV2AccessToken) {
-  const baseUrl = `https://${process.env.AUTH0_DOMAIN}/api/v2/client-grants`;
+  const baseUrl = `https://${process.env.RESETTENANT_AUTH0_DOMAIN}/api/v2/client-grants`;
 
   // check to see if script client has required client grants
   return request.get({
@@ -26,14 +26,14 @@ export function fetchAccessToken (apiV2AccessToken) {
   }, 'get existing client grants')
     .then(grants => {
       const grant = grants.find(g =>
-        g.client_id === process.env.API_CLIENT_ID &&
+        g.client_id === process.env.RESETTENANT_NIC_CLIENT_ID &&
         g.audience === tokenAudience());
       if (!grant) {
         // no grant record exists - create it
         return request.post({
           url: baseUrl,
           json: {
-            client_id: process.env.API_CLIENT_ID,
+            client_id: process.env.RESETTENANT_NIC_CLIENT_ID,
             audience: tokenAudience(),
             scope: REQUIRED_ACCESS_TOKEN_SCOPES
           },
@@ -56,10 +56,10 @@ export function fetchAccessToken (apiV2AccessToken) {
       }
     })
     .then(() => request.post({
-      url: `https://${process.env.AUTH0_DOMAIN}/oauth/token`,
+      url: `https://${process.env.RESETTENANT_AUTH0_DOMAIN}/oauth/token`,
       json: {
-        client_id: process.env.API_CLIENT_ID,
-        client_secret: process.env.API_CLIENT_SECRET,
+        client_id: process.env.RESETTENANT_NIC_CLIENT_ID,
+        client_secret: process.env.RESETTENANT_NIC_CLIENT_SECRET,
         grant_type: 'client_credentials',
         audience: tokenAudience()
       }

--- a/src/recipes/lib/webtask.js
+++ b/src/recipes/lib/webtask.js
@@ -2,14 +2,14 @@ import * as request from './request';
 import querystring from 'querystring';
 
 export function webtaskRegion () {
-  const regionMatch = /^\S*\.(\S*)\.auth0\.com$/.exec(process.env.AUTH0_DOMAIN);
+  const regionMatch = /^\S*\.(\S*)\.auth0\.com$/.exec(process.env.RESETTENANT_AUTH0_DOMAIN);
   return regionMatch ? regionMatch[1] : 'us';
 }
 
 export function apiManager (entityName, idField, apiPath, accessToken, pager = getPage => getPage({})) {
   const region = webtaskRegion();
   const apiRegion = region === 'us' ? '' : `-${region}`;
-  const rootUrl = `https://sandbox${apiRegion}.it.auth0.com${apiPath}/${process.env.AUTH0_TENANT}`;
+  const rootUrl = `https://sandbox${apiRegion}.it.auth0.com${apiPath}/${process.env.RESETTENANT_AUTH0_TENANT}`;
 
   return {
     entityName,


### PR DESCRIPTION
As of about a week ago, you can no longer (easily) obtain non-expiring Auth0 Management API tokens, which is what the [previous version of the README](https://github.com/twistedstream/auth0-reset-tenant/blob/f1287732a98e2b07abcd8ab94aef7982aee66838/README.md) assumed when it talked about using the **TOKEN GENERATOR**, which is no more. This PR includes updates to support a simpler model of setting up the required **Non Interactive Client**. Now you only need one with two client grant scopes for the Management API: `read:client_grants` and `update:client_grants`

This means you can easily add the Non Interactive Client using the Dashboard and be up and running with the script in no time.

The other thing this PR does (and why it revs the version to `2.0.0`) is to use namespaced names in the configuration files (`.env` and `.auth0-reset-tenant-env`). This was done, especially for `.env` files such that you could mix other configuration in that file and avoid any naming collisions. For example, if you were using a local `.env` to control the configuration of an actual website.

Finally, I cleaned up the README in general quite a bit to make it more clear how to use this tool and its associated configuration.